### PR TITLE
add swap to avoid wait on boot

### DIFF
--- a/test/fixtures/builder-linode/minimal.json
+++ b/test/fixtures/builder-linode/minimal.json
@@ -8,7 +8,7 @@
         "linode_token": "{{user `linode_token`}}",
 
         "region": "us-central",
-        "swap_size": 0,
+        "swap_size": 256,
         "image": "linode/debian9",
         "instance_type": "g6-nanode-1",
         "instance_label": "packerbats-minimal-{{timestamp}}",


### PR DESCRIPTION
Setting a swap size of `0` causes the boot to wait for 1m 30s (using linode/debian9 image) since it cannot find the swap disk.  This can be seen from the console when booting.

Time to completion of the sample image went from 3m23s to 1m30s.